### PR TITLE
Fix deprecation warnings in tf_serving sample client

### DIFF
--- a/contrib/tf_serving/tfs_sample_client.py
+++ b/contrib/tf_serving/tfs_sample_client.py
@@ -4,8 +4,8 @@ import keras
 import numpy as np
 import tensorflow as tf
 from src.utils import utils
-from grpc.beta import implementations
-from tensorflow_serving.apis import predict_pb2, prediction_service_pb2
+import grpc
+from tensorflow_serving.apis import predict_pb2, prediction_service_pb2_grpc
 
 TFS_HOST = 'localhost'
 TFS_PORT = 8500
@@ -27,8 +27,9 @@ def get_image_quality_predictions(image_path, model_name):
     image = keras.applications.mobilenet.preprocess_input(image)
 
     # Run through model
-    channel = implementations.insecure_channel(TFS_HOST, TFS_PORT)
-    stub = prediction_service_pb2.beta_create_PredictionService_stub(channel)
+    target = f'{TFS_HOST}:{TFS_PORT}'
+    channel = grpc.insecure_channel(target)
+    stub = prediction_service_pb2_grpc.PredictionServiceStub(channel)
     request = predict_pb2.PredictRequest()
     request.model_spec.name = model_name
     request.model_spec.signature_name = 'image_quality'


### PR DESCRIPTION
## Problem Description

`contrib/tf_serving/tfs_sample_client.py` prints deprecation warnings during usage.

### Command

```bash
python C:/Users/tejun/workspace/image-quality-assessment/contrib/tf_serving/tfs_sample_client.py --image-path src/tests/test_images/42039.jpg --model-name mobilenet_aesthetic
```

### Deprecation Output

```
C:\Users\tejun\workspace\image-quality-assessment\venv\lib\site-packages\tensorflow_serving\apis\prediction_service_pb2.py:131: DeprecationWarning: beta_create_PredictionService_stub() method is deprecated. This method will be removed in near future versions of TF Serving. Please switch to GA gRPC API in prediction_service_pb2_grpc.
  'prediction_service_pb2_grpc.', DeprecationWarning)
C:\Users\tejun\workspace\image-quality-assessment\venv\lib\site-packages\tensorflow\contrib\lite\python\__init__.py:26: PendingDeprecationWarning: WARNING: TF Lite has moved from tf.contrib.lite to tf.lite. Please update your imports. This will be a breaking error in TensorFlow version 2.0.
  _warnings.warn(WARNING, PendingDeprecationWarning)
```

## Root Cause

`tensorflow-serving-api@1.10.0` deprecated the beta gRPC API according to [this documentation](https://github.com/tensorflow/serving/releases/tag/1.10.0)

The sample client (`contrib/tf_serving/tfs_sample_client.py`) has a minimum requirement of `tensorflow-serving-api@1.12.*`, according to `requirements.txt` in the working directory. So this deprecation warning will always be printed with this version of the dependency.

## Fix

**Minor Changes**: Replace deprecated APIs with GA versions

## Testing Done

Confirmation that these changes don't break the code. Notice the deprecation warnings are no longer printed in the **Output**

### Command Run

```bash
python C:/Users/tejun/workspace/image-quality-assessment/contrib/tf_serving/tfs_sample_client.py --image-path src/tests/test_images/42039.jpg --model-name mobilenet_aesthetic
```

### Output

```
Using TensorFlow backend.

WARNING: The TensorFlow contrib module will not be included in TensorFlow 2.0.
For more information, please see:
  * https://github.com/tensorflow/community/blob/master/rfcs/20180907-contrib-sunset.md
  * https://github.com/tensorflow/addons
If you depend on functionality not listed there, please file an issue.

{
  "mean_score_prediction": 5.23
}

Process finished with exit code 0
```