### PR TITLE
Small enhancements to file type processing

### DIFF
--- a/src/evaluater/predict.py
+++ b/src/evaluater/predict.py
@@ -10,7 +10,7 @@ from handlers.data_generator import TestDataGenerator
 
 def image_file_to_json(img_path):
     img_dir = os.path.dirname(img_path)
-    img_id = os.path.basename(img_path).split('.')[0]
+    img_id = os.path.basename(img_path)
 
     return img_dir, [{'image_id': img_id}]
 
@@ -20,7 +20,7 @@ def image_dir_to_json(img_dir, img_type='jpg'):
 
     samples = []
     for img_path in img_paths:
-        img_id = os.path.basename(img_path).split('.')[0]
+        img_id = os.path.basename(img_path)
         samples.append({'image_id': img_id})
 
     return samples
@@ -36,7 +36,7 @@ def main(base_model_name, weights_file, image_source, predictions_file, img_form
         image_dir, samples = image_file_to_json(image_source)
     else:
         image_dir = image_source
-        samples = image_dir_to_json(image_dir, img_type='jpg')
+        samples = image_dir_to_json(image_dir, img_format)
 
     # build model and load weights
     nima = Nima(base_model_name, weights=None)

--- a/src/handlers/data_generator.py
+++ b/src/handlers/data_generator.py
@@ -41,7 +41,7 @@ class TrainDataGenerator(tf.keras.utils.Sequence):
 
         for i, sample in enumerate(batch_samples):
             # load and randomly augment image
-            img_file = os.path.join(self.img_dir, '{}.{}'.format(sample['image_id'], self.img_format))
+            img_file = os.path.join(self.img_dir, '{}'.format(sample['image_id']))
             img = utils.load_image(img_file, self.img_load_dims)
             if img is not None:
                 img = utils.random_crop(img, self.img_crop_dims)
@@ -90,7 +90,7 @@ class TestDataGenerator(tf.keras.utils.Sequence):
 
         for i, sample in enumerate(batch_samples):
             # load and randomly augment image
-            img_file = os.path.join(self.img_dir, '{}.{}'.format(sample['image_id'], self.img_format))
+            img_file = os.path.join(self.img_dir, '{}'.format(sample['image_id']))
             img = utils.load_image(img_file, self.img_load_dims)
             if img is not None:
                 X[i, ] = img


### PR DESCRIPTION
1. Enhance the image_id logic to allow files with multiple “.” in the name, like filename.CR2.jpg
2. Replace img_type by img_format when calling image_dir_to_json in predict.py