### PR TITLE
Resolved warning about contrib module not included

### DIFF
--- a/contrib/tf_serving/tfs_sample_client.py
+++ b/contrib/tf_serving/tfs_sample_client.py
@@ -35,7 +35,7 @@ def get_image_quality_predictions(image_path, model_name):
     request.model_spec.signature_name = 'image_quality'
 
     request.inputs['input_image'].CopyFrom(
-        tf.contrib.util.make_tensor_proto(np.expand_dims(image, 0))
+        tf.compat.v1.make_tensor_proto(np.expand_dims(image, 0))
     )
 
     response = stub.Predict(request, 10.0)


### PR DESCRIPTION
I resolved the following warning in the TensorFlow Serving sample client:

WARNING:tensorflow:
The TensorFlow contrib module will not be included in TensorFlow 2.0.
For more information, please see:
  * https://github.com/tensorflow/community/blob/master/rfcs/20180907-contrib-sunset.md
  * https://github.com/tensorflow/addons
  * https://github.com/tensorflow/io (for I/O related ops)
If you depend on functionality not listed there, please file an issue.