### PR TITLE
Updating nvidia public key to the latest up-to-date one

### DIFF
--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -1,5 +1,7 @@
 FROM tensorflow/tensorflow:2.0.0-gpu-py3
 
+RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
+
 # Install system packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
       bzip2 \


### PR DESCRIPTION
GPU build fails due to obsolete public key to nvidia repositories , fixed by specifying the key explicitly.